### PR TITLE
Fix panic when requesting forecast with negative utc offset

### DIFF
--- a/src/forecast.rs
+++ b/src/forecast.rs
@@ -332,7 +332,7 @@ struct ApiForecastResponse {
     pub longitude: Option<f64>,
     pub elevation: Option<f32>,
     pub generationtime_ms: Option<f64>,
-    pub utc_offset_seconds: Option<u64>,
+    pub utc_offset_seconds: Option<i32>,
     pub timezone: Option<String>,
     pub timezone_abbreviation: Option<String>,
     pub current_weather: Option<CurrentWeather>,
@@ -493,14 +493,14 @@ impl client::Client {
 
 fn extract_times(
     input: &HashMap<String, serde_json::Value>,
-    utc_offset_seconds: u64,
+    utc_offset_seconds: i32,
 ) -> Result<Option<Vec<chrono::NaiveDateTime>>, Box<dyn Error>> {
     if let Some(time) = input.get("time") {
         if let Some(time_values) = time.as_array() {
             let mut hourly_datetimes = Vec::new();
 
             for v in time_values.iter() {
-                let unix_tm = match v.as_u64() {
+                let unix_tm = match v.as_i64() {
                     Some(v) => v,
                     None => {
                         return Err("cannot decode properly json input".into());
@@ -508,7 +508,7 @@ fn extract_times(
                 };
 
                 let dd = chrono::Utc
-                    .timestamp_millis_opt(((unix_tm + utc_offset_seconds) * 1000) as i64)
+                    .timestamp_millis_opt((unix_tm + utc_offset_seconds as i64) * 1000)
                     .unwrap()
                     .naive_local();
 


### PR DESCRIPTION
This fixes panics like
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error("invalid value: integer `-25200`, expected u64", line: 1, column: 105)', src/main.rs:45:43
```
When requesting forecast data for a time zone with a negative utc offset.

To reproduce the panic:

```diff
diff --git a/examples/forecast.rs b/examples/forecast.rs
index e775554..0d2d75a 100644
--- a/examples/forecast.rs
+++ b/examples/forecast.rs
@@ -43,7 +43,7 @@ async fn main() {
     opts.precipitation_unit = Some("inch".try_into().unwrap()); // or
 
     // Time zone (default to UTC)
-    opts.time_zone = Some(chrono_tz::Europe::Paris.name().into());
+    opts.time_zone = Some(chrono_tz::America::New_York.name().into());
```