### PR TITLE
Fix wrong parameter name sent for wind speed unit

### DIFF
--- a/src/forecast.rs
+++ b/src/forecast.rs
@@ -250,7 +250,7 @@ impl Options {
         }
 
         match self.wind_speed_unit {
-            Some(v) => params.push(("wind_speed_unit".into(), v.into())),
+            Some(v) => params.push(("windspeed_unit".into(), v.into())),
             None => (),
         }
 


### PR DESCRIPTION
This fixes an issue where forecasting would ignore custom wind speed units due to `wind_speed_unit` being sent to the forecast API instead of the correct `windspeed_unit`.

The open-meteo API ignores the value in that case and returns values in `km/h`.
