### PR TITLE
Add options to set an apikey for forecast and geolocation APIs

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -42,6 +42,21 @@ impl Client {
         Self::default()
     }
 
+    pub fn with_endpoints(
+        forecast_endpoint: &str,
+        archive_endpoint: &str,
+        geocoding_endpoint: &str,
+        air_quality_endpoint: &str,
+    ) -> Client {
+        Self {
+            forecast_endpoint: forecast_endpoint.to_string(),
+            archive_endpoint: archive_endpoint.to_string(),
+            geocoding_endpoint: geocoding_endpoint.to_string(),
+            air_quality_endpoint: air_quality_endpoint.to_string(),
+            ..Default::default()
+        }
+    }
+
     pub fn with_forecast_endpoint(mut self, endpoint: String) -> Client {
         self.forecast_endpoint = endpoint;
         self

--- a/src/forecast.rs
+++ b/src/forecast.rs
@@ -210,6 +210,7 @@ pub struct Options {
     pub end_date: Option<chrono::NaiveDate>,
     pub models: Option<Vec<String>>,
     pub cell_selection: Option<CellSelection>,
+    pub apikey: Option<String>,
 }
 
 impl Default for Options {
@@ -230,6 +231,7 @@ impl Default for Options {
             end_date: None,
             models: None,
             cell_selection: None,
+            apikey: None,
         }
     }
 }
@@ -307,6 +309,10 @@ impl Options {
         match self.cell_selection {
             Some(v) => params.push(("cell_selection".into(), v.into())),
             None => (),
+        }
+
+        if let Some(apikey) = self.apikey {
+            params.push(("apikey".into(), apikey.to_string()));
         }
 
         params

--- a/src/geocoding.rs
+++ b/src/geocoding.rs
@@ -7,6 +7,7 @@ pub struct Options {
     pub name: Option<String>,
     pub language: Option<String>,
     pub count: Option<u16>,
+    pub apikey: Option<String>,
 }
 
 impl Options {
@@ -41,6 +42,10 @@ impl Options {
         match self.count {
             Some(v) => params.push(("count".into(), v.to_string())),
             None => (),
+        }
+
+        if let Some(apikey) = self.apikey {
+            params.push(("apikey".into(), apikey.to_string()));
         }
 
         params


### PR DESCRIPTION
Hi!

This PR:
1. Adds the option to provide an API key in the forecast and geolocation APIs.
2. Adds a new creation method for the Client, so that it is possible to create a non-mult Client with custom endpoints.

Thanks!
